### PR TITLE
fix Dockerfile

### DIFF
--- a/template/src/ABC.Template.Web/Dockerfile
+++ b/template/src/ABC.Template.Web/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 COPY . .
 RUN dotnet restore "src/ABC.Template.Web/ABC.Template.Web.csproj"


### PR DESCRIPTION
This pull request updates the `Dockerfile` for the `ABC.Template.Web` project to use .NET 9.0 instead of .NET 8.0 for both the runtime and SDK.

* [`template/src/ABC.Template.Web/Dockerfile`](diffhunk://#diff-a54a1d96fa7ede93ea6a97176e062a3f8c6f2b2f334300443294d27bab566c55L3-R8): Updated the base image from `mcr.microsoft.com/dotnet/aspnet:8.0` to `mcr.microsoft.com/dotnet/aspnet:9.0` and the build image from `mcr.microsoft.com/dotnet/sdk:8.0` to `mcr.microsoft.com/dotnet/sdk:9.0`.