### PR TITLE
增加FastEndpointsVersion统一版本号配置

### DIFF
--- a/eng/versions.props
+++ b/eng/versions.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.8.0</VersionPrefix>
+    <VersionPrefix>2.9.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/template/Directory.Build.targets
+++ b/template/Directory.Build.targets
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
-    <NetCorePalVersion>2.8.5</NetCorePalVersion>
+    <NetCorePalVersion>2.9.0</NetCorePalVersion>
+    <FastEndpointsVersion>7.0.1</FastEndpointsVersion>
     <FrameworkVersion>9.0.0</FrameworkVersion>
     <ExtensionsVersion>9.0.0</ExtensionsVersion>
     <EntityFrameworkVersion>9.0.0</EntityFrameworkVersion>

--- a/template/src/ABC.Template.Web/ABC.Template.Web.csproj
+++ b/template/src/ABC.Template.Web/ABC.Template.Web.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="AspNet.Security.OAuth.Weixin" Version="9.0.0" />
     <PackageReference Include="DotNetCore.CAP.Dashboard" Version="8.3.2" />
     <PackageReference Include="DotNetCore.CAP.RabbitMQ" Version="8.3.2" />
-    <PackageReference Include="FastEndpoints" Version="6.1.0" />
-    <PackageReference Include="FastEndpoints.Swagger" Version="6.1.0" />
+    <PackageReference Include="FastEndpoints" Version="$(FastEndpointsVersion)" />
+    <PackageReference Include="FastEndpoints.Swagger" Version="$(FastEndpointsVersion)" />
     <PackageReference Include="FastEndpoints.Swagger.Swashbuckle" Version="2.3.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.17" />

--- a/template/src/ABC.Template.Web/Endpoints/UserEndpoints/AuthEndpoint.cs
+++ b/template/src/ABC.Template.Web/Endpoints/UserEndpoints/AuthEndpoint.cs
@@ -11,6 +11,6 @@ public class AuthEndpoint : EndpointWithoutRequest<ResponseData<bool>>
 {
     public override Task HandleAsync(CancellationToken ct)
     {
-        return SendAsync(true.AsResponseData(), cancellation: ct);
+        return Send.OkAsync(true.AsResponseData(), cancellation: ct);
     }
 }

--- a/template/src/ABC.Template.Web/Endpoints/UserEndpoints/LoginEndpoint.cs
+++ b/template/src/ABC.Template.Web/Endpoints/UserEndpoints/LoginEndpoint.cs
@@ -19,6 +19,6 @@ public class LoginEndpoint(IJwtProvider jwtProvider) : Endpoint<LoginRequest, Re
             new JwtData("netcorepal", "netcorepal",
                 [new Claim("name", req.Username)],
                 DateTime.Now, DateTime.Now.AddDays(1)));
-        await SendAsync(jwt.AsResponseData(), cancellation: ct);
+        await Send.OkAsync(jwt.AsResponseData(), cancellation: ct);
     }
 }


### PR DESCRIPTION
## 模板项目修改内容

- 升级 `netcorepal` 框架版本到 `2.9.0`
- 增加 `<FastEndpointsVersion>` 版本号配置
- `FastEndpoints` 版本升级到 `7.0.1`，有些重要调整查看[官方7.0.1更新文档](https://github.com/FastEndpoints/FastEndpoints/releases/tag/v7.0.1)

## FastEndpoint 7.0.1 破坏性更新

### 端点响应发送方法的 API 变更

今后，通过端点的 Send 属性访问响应发送方法，如下所示：
```csharp
public override async Task HandleAsync(CancellationToken c)
{
    await Send.OkAsync("hello world!");
}
```

**批量修改方法(Rider)**

- 选中要修改的代码 `Ctl + Shift + H`
- 修改新的响应代码

<img width="552" height="331" alt="image" src="https://github.com/user-attachments/assets/eaea6b36-922a-4a3a-aaf4-7afcfbb2d1be" />
